### PR TITLE
update README: add extension pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 - vscode-icons: 图标优化
 - YAML: YAML 文件支持
 
+也可以搜索"geektime rust"找到`rust extension pack for geektime rust bootcamp`一键安装所有需要的插件, marketplace地址: https://marketplace.visualstudio.com/items?itemName=azurepx.rust-extension-pack-for-geektime-rust-bootcamp
+
 ### 安装 cargo generate
 
 cargo generate 是一个用于生成项目模板的工具。它可以使用已有的 github repo 作为模版生成新的项目。


### PR DESCRIPTION
Update the `README` and provide an alternative way(extension pack) to install vscode-extensions for the rust bootcamp.

Extension pack: https://marketplace.visualstudio.com/items?itemName=azurepx.rust-extension-pack-for-geektime-rust-bootcamp

<img width="950" alt="Screenshot 2024-04-19 at 13 24 30" src="https://github.com/tyr-rust-bootcamp/template/assets/153528619/5853aa74-60d8-46ea-9129-8eae08273c06">

<img width="335" alt="Screenshot 2024-04-19 at 13 25 56" src="https://github.com/tyr-rust-bootcamp/template/assets/153528619/bb4d4dd3-669d-4149-b976-9ed5de95856b">

Please help review it and hope this helps.

Thanks.