### PR TITLE
feat: add deny fetch commit with pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,13 @@ repos:
         language: rust
         files: \.rs$
         args: []
+      - id: cargo-deny-fetch
+        name: cargo deny fetch
+        description: deny fetch
+        entry: bash -c 'cargo deny fetch'
+        language: rust
+        files: \.rs$
+        args: []
       - id: cargo-deny
         name: cargo deny check
         description: Check cargo dependencies


### PR DESCRIPTION
```bash
cargo deny --version
cargo-deny 0.14.24
```
在 `0.14.24` 版本中 运行 cargo deny 会抛出异常
```bash
2024-06-17 03:19:13 [ERROR] failed to open advisory database: "/Users/hildxd/.cargo/advisory-db/github.com-2f857891b7f43c59" does not appear to be a git repository: Could not retrieve metadata of "/Users/hildxd/.cargo/advisory-db/github.com-2f857891b7f43c59": No such file or directory (os error 2)
```
江昊老师说可以用 `deny fetch` 解决