### PR TITLE
解决 cargo generate tyr-rust-bootcamp/template 报错

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+exclude = ["cliff.toml"]


### PR DESCRIPTION
 解决 cargo generate tyr-rust-bootcamp/template #15 报错
```
Error: Substitution skipped, found invalid syntax in
        cliff.toml

Consider adding these files to a `cargo-generate.toml` in the template repo to skip substitution on these files.

Learn more: https://github.com/cargo-generate/cargo-generate#include--exclude.
```